### PR TITLE
Use iterators for the transition_for() loop.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,12 +94,7 @@ impl State<'_> {
         // The transitions array is sorted by match_byte() value, but there are
         // usually very few entries; benchmarking showed that using binary_search_by
         // here gave no benefit (possibly slightly slower).
-        for t in self.transitions() {
-            if t.match_byte() == b {
-                return Some(*t);
-            }
-        }
-        None
+        self.transitions().iter().copied().find(|t| t.match_byte() == b)
     }
     #[allow(dead_code)]
     fn deep_show(&self, prefix: &str, dic: &Level) {


### PR DESCRIPTION
I hope you don't mind but I was noodling around with your code and linux `perf` reported the `transition_for()` loop is the hottest part of the bench.

Converting from C-style for loop into Rust-style iterators gives a small (4,000,000 ns/iter) win on both my linux and macOS machines by allowing the Rust compiler to unroll the loop 4 times to save on loop overhead.