### PR TITLE
Switch benchmark suite to use criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,8 @@ memmap = "0.7.0"
 arrayref = "0.3.5"
 
 [dev-dependencies]
-lazy_static = "1.2.0"
+criterion = "0.3"
+
+[[bench]]
+name = "bench"
+harness = false


### PR DESCRIPTION
the state of benchmarking in Rust is a bit fuzzy. The "default" bench suite is "deprecated" and not supported, while everyone is waiting for `criterion` to become the default.

In the meantime, criterion offers a statistically sound approach with a solid API and ability to plot graphs, compare between sample sizes etc. Oh, and it works on stable :)

I separated out two benchmarks - for construction and finding hyphen values. Feel free to fine-tune the benchmarks to better reflect what you want to be measuring.