### PR TITLE
Do not specify default options in cbindgen.toml

### DIFF
--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -2,7 +2,7 @@
 # Some values are commented out because their absence is the real default.
 #
 # See https://github.com/eqrion/cbindgen/blob/master/docs.md#cbindgentoml
-# for detailed documentation of every option here.
+# for detailed documentation of available options.
 
 language = "C"
 
@@ -28,87 +28,5 @@ autogen_warning = """/*
  */
 """
 include_version = false
-# namespace = "my_namespace"
-namespaces = []
-# using_namespaces = []
-sys_includes = ["stdbool.h","stdint.h"]
-includes = []
+sys_includes = ["stdbool.h", "stdint.h"]
 no_includes = true
-
-############################ Code Style Options ################################
-
-braces = "SameLine"
-line_length = 100
-tab_width = 2
-documentation_style = "auto"
-
-############################# Codegen Options ##################################
-
-style = "both"
-
-[defines]
-# "target_os = freebsd" = "DEFINE_FREEBSD"
-# "feature = serde" = "DEFINE_SERDE"
-
-[export]
-include = []
-exclude = []
-# prefix = "CAPI_"
-item_types = []
-renaming_overrides_prefixing = false
-
-[export.rename]
-
-[export.body]
-
-[fn]
-rename_args = "None"
-# must_use = "MUST_USE_FUNC"
-# prefix = "START_FUNC"
-# postfix = "END_FUNC"
-args = "auto"
-
-[struct]
-rename_fields = "None"
-# must_use = "MUST_USE_STRUCT"
-derive_constructor = false
-derive_eq = false
-derive_neq = false
-derive_lt = false
-derive_lte = false
-derive_gt = false
-derive_gte = false
-
-[enum]
-rename_variants = "None"
-# must_use = "MUST_USE_ENUM"
-add_sentinel = false
-prefix_with_name = false
-derive_helper_methods = false
-derive_const_casts = false
-derive_mut_casts = false
-# cast_assert_name = "ASSERT"
-derive_tagged_enum_destructor = false
-derive_tagged_enum_copy_constructor = false
-private_default_tagged_enum_constructor = false
-
-[const]
-allow_static_const = true
-
-[macro_expansion]
-bitflags = false
-
-############## Options for How Your Rust library Should Be Parsed ##############
-
-[parse]
-parse_deps = false
-# include = []
-exclude = []
-clean = false
-extra_bindings = []
-
-[parse.expand]
-crates = []
-all_features = false
-default_features = true
-features = []


### PR DESCRIPTION
It always confuses me when I grep for exotic options and see them overridden
here.

I verified that this doesn't change the generated bindings in mozilla-central.