### PR TITLE
Remove dependency on env_logger.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mapped_hyph"
 description = "Hyphenation using precompiled memory-mapped tables"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Jonathan Kew <jfkthame@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 memmap = "0.7.0"
 arrayref = "0.3.5"
 log = "0.4"
-env_logger = "0.7.1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/bin/hyf_compile.rs
+++ b/src/bin/hyf_compile.rs
@@ -7,14 +7,31 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+extern crate log;
 extern crate mapped_hyph;
-extern crate env_logger;
 
 use std::env;
 use std::fs::File;
 
+struct Logger {}
+
+impl log::Log for Logger {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        eprintln!("{} - {}", record.level(), record.args());
+    }
+
+    fn flush(&self) {}
+}
+
+static LOGGER: Logger = Logger {};
+
 fn main() -> std::io::Result<()> {
-    env_logger::init();
+    unsafe { log::set_logger_racy(&LOGGER).unwrap() };
+
     let args: Vec<String> = env::args().collect();
     if args.len() == 3 {
         let in_file = File::open(&args[1])?;


### PR DESCRIPTION
This allows to more easily update env_logger in Gecko.

Only the binary needed it, and Cargo doesn't allow us to specify
dependencies only for it, so replace it with a super-simple logger
instead.