### PR TITLE
Replace dependency to memmap with memmap2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-memmap = "0.7.0"
+memmap2 = "0.2.2"
 arrayref = "0.3.5"
 log = "0.4"
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -15,7 +15,7 @@ use std::io::Read;
 use std::os::raw::c_char;
 use std::str::Utf8Error;
 
-use memmap::Mmap;
+use memmap2::Mmap;
 
 use super::Hyphenator;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 
 #[macro_use]
 extern crate arrayref;
-extern crate memmap;
+extern crate memmap2;
 #[macro_use]
 extern crate log;
 
@@ -19,7 +19,7 @@ use std::cmp::max;
 use std::fs::File;
 use std::mem;
 
-use memmap::Mmap;
+use memmap2::Mmap;
 
 // Make submodules available publicly.
 pub mod builder;
@@ -619,7 +619,7 @@ impl Hyphenator<'_> {
 /// Load the compiled hyphenation file at `dic_path`, if present.
 ///
 /// Returns `None` if the specified file cannot be opened or mapped,
-/// otherwise returns a `memmap::Mmap` mapping the file.
+/// otherwise returns a `memmap2::Mmap` mapping the file.
 ///
 /// # Safety
 ///


### PR DESCRIPTION
The crate [memmap](https://crates.io/crates/memmap) has been marked unmaintained, see the [advisory](https://rustsec.org/advisories/RUSTSEC-2020-0077).

This PR replaces the dependency with [memmap2](https://crates.io/crates/memmap2), which is a maintained fork of memmap.