### PR TITLE
Allow newer versions of memmap2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-memmap2 = "0.2.2"
+memmap2 = { version = ">=0.2,<=0.5" }
 arrayref = "0.3.5"
 log = "0.4"
 


### PR DESCRIPTION
But keep compat with the older ones so as to be semver-compatible, the
load_file function being public.